### PR TITLE
Fix import command when running on unconfigured bot

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -283,7 +283,7 @@ impl DB {
 
     pub async fn get_last_serial(&self) -> anyhow::Result<usize> {
         let mut result = self.db.query("SELECT serial FROM config:config").await?;
-        let _t: Option<usize> = result.take((0, "serial"))?;
-        _t.context("Can't deserialize serial")
+        let t: Option<usize> = result.take((0, "serial"))?;
+        Ok(t.unwrap_or_default())
     }
 }


### PR DESCRIPTION
This PR consists of two commits, first adds a test and the second fixes it.
Without the fix import fails with an error "Error: Can't deserialize serial".