### PR TITLE
fix(frontend): support Chrome 74

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [solidPlugin(), unocssPlugin()],
     build: {
+      target: ["es2020", "edge88", "firefox78", "chrome74", "safari14"],
       rollupOptions: {
         input: {
           //@ts-ignore


### PR DESCRIPTION
The set of targets is the default for Vite,
but with chrome87 replaced with chrome74.

I have tested on a device with Chrome 74 WebView that the app displays the page instead of the blank screen now.

Fixes #7 